### PR TITLE
BUG: ADD has an opcode of 0, that was thought to be a blank line -- o…

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -275,9 +275,9 @@ void scan(char *fn) {
     unsigned char opcode, mask1, mask2;
     while ((line = readline("", fp)) != NULL) {
         normalize(line);
+        op = split(line, " ", 1);
         squish(line);
-        if (strlen(line) > 0) {
-            op = split(line, " ", 1);
+        if (strlen(op) > 0 || strlen(line) > 0) {
             if (*(op + strlen(op)-1) == ':')
                 addLabel(op, byte);
             else
@@ -309,7 +309,7 @@ void assemble(char *fn) {
 
             if (*(op + strlen(op)-1) == ':') {
                 ;   // do we need to do anything here?
-            } else if (opcode > 1 && strcmp(op, "") != 0) {
+            } else if (opcode != 1 && strcmp(op, "") != 0) {
                 mask1 = 0;
                 mask2 = 0;
 

--- a/common.h
+++ b/common.h
@@ -1,4 +1,5 @@
-#define MEMSIZE (256*256)    /* 64K */
+//#define MEMSIZE (256*256)    /* 64K */
+#define MEMSIZE (256)
 
 extern unsigned char memory[];
 extern volatile int keepRunning;


### PR DESCRIPTION
Found BUG where a line without any text returns an opcode of 1, all opcodes were thought to be in the high nibble, however ADD has an opcode of 0 so need to check != 1 instead of > 0 for a valid opcode.

Also reduced memory down so there are only 256 bytes of memory.